### PR TITLE
Hotfix: Change odlc_move_to image capture to run continuously

### DIFF
--- a/flight/camera.py
+++ b/flight/camera.py
@@ -443,29 +443,31 @@ class CameraIRL(Camera):
         """
         info: dict[str, CameraParameters] = {}
 
-        await move_to(
-            drone,
-            latitude,
-            longitude,
-            altitude,
-            airspeed=5.0,
-            tolerance=WAYPOINT_TOLERANCE,
+        goto_task: asyncio.Task[None] = asyncio.ensure_future(
+            move_to(
+                drone,
+                latitude,
+                longitude,
+                altitude,
+                airspeed=5.0,
+                tolerance=WAYPOINT_TOLERANCE,
+            )
         )
 
         if take_photos:
             # Point the gimbal straight down
             self.camera.requestSetAngles(0, -90)
 
-        await asyncio.sleep(2)
+        while not goto_task.done():
+            if not take_photos:
+                await asyncio.sleep(1)
+                continue
 
-        if not take_photos:
-            return
-
-        camera_parameters: CameraParameters = await self._get_camera_parameters(drone)
-        file_path: str
-        _, file_path = await self.capture_photo()
-        point: dict[str, CameraParameters] = {file_path: camera_parameters}
-        info.update(point)
+            camera_parameters: CameraParameters = await self._get_camera_parameters(drone)
+            file_path: str
+            _, file_path = await self.capture_photo()
+            point: dict[str, CameraParameters] = {file_path: camera_parameters}
+            info.update(point)
 
         current_photos: dict[str, CameraParameters] = {}
         if os.path.exists("flight/data/camera.json"):
@@ -479,10 +481,6 @@ class CameraIRL(Camera):
         camera: TextIO
         with open("flight/data/camera.json", "w", encoding="ascii") as camera:
             json.dump(current_photos | info, camera)
-
-            # tell machine to sleep to prevent constant polling, preventing battery drain
-            await asyncio.sleep(1)
-        return
 
     async def _get_camera_parameters(self, drone: dronekit.Vehicle) -> CameraParameters:
         """


### PR DESCRIPTION
Pretty simple change. Now that we are using a gimbal this year we aren't restricted to only taking pictures while the drone is not moving, so we want to capture photos while moving to have more data to find objects in.