### PR TITLE
Add image tiling to YOLO image inference

### DIFF
--- a/vision/yolo/model.py
+++ b/vision/yolo/model.py
@@ -554,7 +554,11 @@ class YOLO:
             trigger.results = results
             trigger.completed()
 
-        image: Image = cv2.imread(image_path).astype(np.uint8)
+        raw_image: cv2.typing.MatLike = cv2.imread(image_path)
+        if raw_image is None:
+            logging.error("%s is not an image, skipping", image_path)
+            return []
+        image: Image = raw_image.astype(np.uint8)
         logging.info("Processing image: %s", image_path)
         height: int
         width: int

--- a/vision/yolo/model.py
+++ b/vision/yolo/model.py
@@ -1,6 +1,7 @@
 """This file contains the class that implements and runs the YOLO model on images we capture."""
 
 import asyncio
+from dataclasses import dataclass
 import logging
 import os
 
@@ -97,6 +98,26 @@ ALL_COCO_CLASSES: dict[int, str] = {
     78: "hair drier",
     79: "toothbrush",
 }
+
+
+@dataclass
+class CroppedImage:
+    """
+    A class representing a cropped image.
+
+    Attributes
+    ----------
+    image : npt.NDArray[np.float32]
+        The cropped image.
+    x : int
+        The x-axis offset of the cropped image from the original image.
+    y : int
+        The y-axis offset of the cropped image from the original image.
+    """
+
+    image: npt.NDArray[np.float32]
+    x: int
+    y: int
 
 
 class ImageTrigger:
@@ -358,16 +379,52 @@ class YOLO:
         """
         # Convert the cv2 image to RGB and resize it to the input size of the model
         image_rgb: cv2.typing.MatLike = cv2.cvtColor(image, cv2.COLOR_BGR2RGB)
-        resized: cv2.typing.MatLike = cv2.resize(image_rgb, (self.input_width, self.input_height))
 
         # Scale input pixel value to 0 to 1
-        input_image: npt.NDArray[np.float32] = resized / 255.0
+        input_image: npt.NDArray[np.float32] = image_rgb / 255.0
         input_image = input_image.transpose(2, 0, 1)
         input_tensor: npt.NDArray[np.float32] = input_image[np.newaxis, :, :, :].astype(np.float32)
         return input_tensor
 
+    def _tile_image(
+        self, image: npt.NDArray[np.float32], width: int, height: int
+    ) -> list[CroppedImage]:
+        """
+        Tiles the provided image into smaller images of the given width and height.
+        Makes sure that every pixel of the image is covered by at least one tile.
+
+        Parameters
+        ----------
+        image : npt.NDArray[np.float32]
+            The image to be tiled.
+        width : int
+            The width of each tile.
+        height : int
+            The height of each tile.
+
+        Returns
+        -------
+        list[CroppedImage]
+            A list of the cropped images.
+        """
+        images: list[CroppedImage] = []
+        i: int
+        j: int
+        for i in range(0, image.shape[2], height):
+            if i + height > image.shape[2]:
+                i = image.shape[2] - height
+            for j in range(0, image.shape[3], width):
+                if j + width > image.shape[3]:
+                    j = image.shape[3] - width
+                cropped_image = image[:, :, i : i + height, j : j + width]
+                images.append(CroppedImage(cropped_image, j, i))
+        return images
+
     def _filter_output(
-        self, output: list[npt.NDArray[np.float32]], image_size: tuple[int, int]
+        self,
+        output: list[npt.NDArray[np.float32]],
+        image_size: tuple[int, int],
+        offset: tuple[int, int],
     ) -> dict[int, tuple[npt.NDArray[np.float32], float]]:
         """
         Converts the output array of the model to a dictionary of the best predictions.
@@ -378,6 +435,8 @@ class YOLO:
             The output array from the model.
         image_size : tuple[int, int]
             The pixel size of the input image. (W, H)
+        offset : tuple[int, int]
+            The offset of the cropped image from the original image.
 
         Returns
         -------
@@ -425,6 +484,12 @@ class YOLO:
             box[1] -= box[3] / 2  # Y1
             box[2] += box[0]  # X2
             box[3] += box[1]  # Y2
+
+            # Apply offset
+            box[0] += offset[0]
+            box[1] += offset[1]
+            box[2] += offset[0]
+            box[3] += offset[1]
 
         # Log results if desired
         if self.log_results:
@@ -484,33 +549,48 @@ class YOLO:
                 If an error occurs during processing.
             """
             if error:
+                logging.error(error)
                 raise ValueError(f"Error occurred: {error}")
             trigger.results = results
             trigger.completed()
 
         image: Image = cv2.imread(image_path).astype(np.uint8)
+        logging.info("Processing image: %s", image_path)
         height: int
         width: int
         height, width = image.shape[:2]
         processed_image: npt.NDArray[np.float32] = self._convert_image(image)
-        trigger: ImageTrigger = ImageTrigger(image_path)
-        logging.info("Processing image: %s", image_path)
-        self.onnx_session.run_async(
-            self.output_names,
-            {"images": processed_image},
-            _onnx_callback,
-            trigger,
-        )
-        while not trigger.trigger:
-            await asyncio.sleep(0.1)
 
-        if not trigger.results:
-            raise ValueError("No results found")
-
-        # Results are ready to process
-        results: dict[int, tuple[npt.NDArray[np.float32], float]] = self._filter_output(
-            trigger.results, (width, height)
+        # Tile images into input shape size
+        tiles: list[CroppedImage] = self._tile_image(
+            processed_image, self.input_width, self.input_height
         )
+
+        total_results: dict[int, tuple[npt.NDArray[np.float32], float]] = {}
+        for tile in tiles:
+            trigger: ImageTrigger = ImageTrigger(image_path)
+            self.onnx_session.run_async(
+                self.output_names,
+                {"images": tile.image},
+                _onnx_callback,
+                trigger,
+            )
+            while not trigger.trigger:
+                await asyncio.sleep(0.1)
+
+            if not trigger.results:
+                raise ValueError("No results found")
+
+            # Consolidate results to best predictions
+            # Also convert to x,y coords in the original image
+            results = self._filter_output(
+                trigger.results, (self.input_width, self.input_height), (tile.x, tile.y)
+            )
+
+            for category, (box, confidence) in results.items():
+                if category not in total_results or confidence > total_results[category][1]:
+                    total_results[category] = (box, confidence)
+
         detections: list[ObjectDetection] = [
             ObjectDetection(
                 image_path,
@@ -519,7 +599,7 @@ class YOLO:
                 confidence,
                 (height, width),
             )
-            for (category, (box, confidence)) in results.items()
+            for (category, (box, confidence)) in total_results.items()
         ]
 
         return detections

--- a/vision/yolo/model.py
+++ b/vision/yolo/model.py
@@ -110,9 +110,9 @@ class CroppedImage:
     image : npt.NDArray[np.float32]
         The cropped image.
     x : int
-        The x-axis offset of the cropped image from the original image.
+        The x-axis offset of the cropped image from the left edge of the original image.
     y : int
-        The y-axis offset of the cropped image from the original image.
+        The y-axis offset of the cropped image from the top edge of the original image.
     """
 
     image: npt.NDArray[np.float32]
@@ -391,7 +391,10 @@ class YOLO:
     ) -> list[CroppedImage]:
         """
         Tiles the provided image into smaller images of the given width and height.
-        Makes sure that every pixel of the image is covered by at least one tile.
+        The tiles on the bottom and right edges have a chance of overlapping with
+        other tiles if the image size is not a multiple of the tile size.
+        This is done intentionally to ensure that every pixel of the image
+        is covered by at least one tile so that no objects are missed.
 
         Parameters
         ----------
@@ -408,14 +411,16 @@ class YOLO:
             A list of the cropped images.
         """
         images: list[CroppedImage] = []
+        image_height: int = image.shape[2]
+        image_width: int = image.shape[3]
         i: int
         j: int
-        for i in range(0, image.shape[2], height):
-            if i + height > image.shape[2]:
-                i = image.shape[2] - height
-            for j in range(0, image.shape[3], width):
-                if j + width > image.shape[3]:
-                    j = image.shape[3] - width
+        for i in range(0, image_height, height):
+            if i + height > image_height:
+                i = image_height - height
+            for j in range(0, image_width, width):
+                if j + width > image_width:
+                    j = image_width - width
                 cropped_image = image[:, :, i : i + height, j : j + width]
                 images.append(CroppedImage(cropped_image, j, i))
         return images
@@ -474,22 +479,20 @@ class YOLO:
         box: npt.NDArray[np.float32]
         for _, (box, _) in best_guesses.items():
             # Fix scaling
-            box[0] = box[0] / self.input_width * image_size[0]  # X
-            box[1] = box[1] / self.input_height * image_size[1]  # Y
-            box[2] = box[2] / self.input_width * image_size[0]  # W
-            box[3] = box[3] / self.input_height * image_size[1]  # H
-
-            # Convert to 2 (x, y) coordinates
-            box[0] -= box[2] / 2  # X1
-            box[1] -= box[3] / 2  # Y1
-            box[2] += box[0]  # X2
-            box[3] += box[1]  # Y2
+            x_mid: np.float32 = box[0] / self.input_width * image_size[0]  # X
+            y_mid: np.float32 = box[1] / self.input_height * image_size[1]  # Y
+            width: np.float32 = box[2] / self.input_width * image_size[0]
+            height: np.float32 = box[3] / self.input_height * image_size[1]
 
             # Apply offset
-            box[0] += offset[0]
-            box[1] += offset[1]
-            box[2] += offset[0]
-            box[3] += offset[1]
+            x_mid += offset[0]
+            y_mid += offset[1]
+
+            # Convert to 2 (x, y) coordinates
+            box[0] = x_mid - (width / 2)  # X1
+            box[1] = y_mid - (height / 2)  # Y1
+            box[2] = x_mid + (width / 2)  # X2
+            box[3] = y_mid + (height / 2)  # Y2
 
         # Log results if desired
         if self.log_results:


### PR DESCRIPTION
The current YOLO implementation resizes the entire image down to the 640x640 size the the model accepts. This adds changes to convert input images to 640x640 chunks and runs the inference on those, hopefully allowing for more accurate results.

Closes #68