### PR TITLE
Multiple ODLC pipeline fixes

### DIFF
--- a/flight/data/golf_data.json
+++ b/flight/data/golf_data.json
@@ -1,121 +1,139 @@
 {
-    "flyzones": {
-        "altitudeMin": 22.86,
-        "altitudeMax": 45.72,
-        "boundaryPoints": [
-            {
-                "latitude": 37.9489421,
-                "longitude": -91.7845482
-            },
-            {
-                "latitude": 37.9486158,
-                "longitude": -91.784338
-            },
-            {
-                "latitude": 37.9483237,
-                "longitude": -91.7845582
-            },
-            {
-                "latitude": 37.947808,
-                "longitude": -91.7835614
-            },
-            {
-                "latitude": 37.9482711,
-                "longitude": -91.7830542
-            },
-            {
-                "latitude": 37.9489421,
-                "longitude": -91.7845482
-            }
-        ],
-        "odlcBoundary": [
-            {
-                "latitude": 37.9487052,
-                "longitude": -91.7841678
-            },
-            {
-                "latitude": 37.9482632,
-                "longitude": -91.783211
-            },
-            {
-                "latitude": 37.9479054,
-                "longitude": -91.7835614
-            },
-            {
-                "latitude": 37.9483448,
-                "longitude": -91.7844481
-            }
-        ],
-        "mappingBoundary": [
-            {
-                "latitude": 37.9487052,
-                "longitude": -91.7841678
-            },
-            {
-                "latitude": 37.9482632,
-                "longitude": -91.783211
-            },
-            {
-                "latitude": 37.9479054,
-                "longitude": -91.7835614
-            },
-            {
-                "latitude": 37.9483448,
-                "longitude": -91.7844481
-            }
-        ]
+  "flyzones": {
+    "altitudeMin": 22.86,
+    "altitudeMax": 45.72,
+    "boundaryPoints": [
+      {
+        "latitude": 37.9489421,
+        "longitude": -91.7845482
+      },
+      {
+        "latitude": 37.9486158,
+        "longitude": -91.784338
+      },
+      {
+        "latitude": 37.9483237,
+        "longitude": -91.7845582
+      },
+      {
+        "latitude": 37.947808,
+        "longitude": -91.7835614
+      },
+      {
+        "latitude": 37.9482711,
+        "longitude": -91.7830542
+      },
+      {
+        "latitude": 37.9489421,
+        "longitude": -91.7845482
+      }
+    ],
+    "odlcBoundary": [
+      {
+        "latitude": 37.9487052,
+        "longitude": -91.7841678
+      },
+      {
+        "latitude": 37.9482632,
+        "longitude": -91.783211
+      },
+      {
+        "latitude": 37.9479054,
+        "longitude": -91.7835614
+      },
+      {
+        "latitude": 37.9483448,
+        "longitude": -91.7844481
+      }
+    ],
+    "mappingBoundary": [
+      {
+        "latitude": 37.9487052,
+        "longitude": -91.7841678
+      },
+      {
+        "latitude": 37.9482632,
+        "longitude": -91.783211
+      },
+      {
+        "latitude": 37.9479054,
+        "longitude": -91.7835614
+      },
+      {
+        "latitude": 37.9483448,
+        "longitude": -91.7844481
+      }
+    ]
+  },
+  "waypoints": [
+    {
+      "latitude": 37.9486921,
+      "longitude": -91.7841599,
+      "altitude": 26
     },
-    "waypoints": [
-        {
-            "latitude": 37.9486921,
-            "longitude": -91.7841599,
-            "altitude": 26
-        },
-        {
-            "latitude": 37.9482764,
-            "longitude": -91.7832256,
-            "altitude": 26
-        },
-        {
-            "latitude": 37.9479159,
-            "longitude": -91.7835693,
-            "altitude": 26
-        },
-        {
-            "latitude": 37.9483448,
-            "longitude": -91.7844035,
-            "altitude": 26
-        },
-        {
-            "latitude": 37.9488342,
-            "longitude": -91.7844135,
-            "altitude": 26
-        },
-        {
-            "latitude": 37.9483264,
-            "longitude": -91.7838496,
-            "altitude": 26
-        }
-    ],
-    "odlcAltitude": 26,
-    "odlcHeading": 13,
-    "odlcWaypoints": [
-        {
-            "latitude": 37.9483658,
-            "longitude": -91.78423
-        },
-        {
-            "latitude": 37.9485711,
-            "longitude": -91.7840565
-        },
-        {
-            "latitude": 37.9480343,
-            "longitude": -91.7835993
-        },
-        {
-            "latitude": 37.9482658,
-            "longitude": -91.7833991
-        }
-    ],
-    "airdropAltitude": 16.0
+    {
+      "latitude": 37.9482764,
+      "longitude": -91.7832256,
+      "altitude": 26
+    },
+    {
+      "latitude": 37.9479159,
+      "longitude": -91.7835693,
+      "altitude": 26
+    },
+    {
+      "latitude": 37.9483448,
+      "longitude": -91.7844035,
+      "altitude": 26
+    },
+    {
+      "latitude": 37.9488342,
+      "longitude": -91.7844135,
+      "altitude": 26
+    },
+    {
+      "latitude": 37.9483264,
+      "longitude": -91.7838496,
+      "altitude": 26
+    }
+  ],
+  "odlcAltitude": 26,
+  "odlcHeading": 13,
+  "odlcWaypoints": [
+    {
+      "latitude": 37.9483658,
+      "longitude": -91.78423
+    },
+    {
+      "latitude": 37.9485711,
+      "longitude": -91.7840565
+    },
+    {
+      "latitude": 37.9480343,
+      "longitude": -91.7835993
+    },
+    {
+      "latitude": 37.9482658,
+      "longitude": -91.7833991
+    }
+  ],
+  "defaultAirdropPoints": [
+    {
+      "latitude": 37.94855,
+      "longitude": -91.78399
+    },
+    {
+      "latitude": 37.94839,
+      "longitude": -91.78425
+    },
+    {
+      "latitude": 37.94836,
+      "longitude": -91.78352
+    },
+    {
+      "latitude": 37.94813,
+      "longitude": -91.78372
+    }
+  ],
+  "airdropAltitude": 16.0
 }

--- a/flight/data/waypoint_data.json
+++ b/flight/data/waypoint_data.json
@@ -1,243 +1,279 @@
 {
-    "flyzones": {
-        "altitudeMin": 23.4696,
-        "altitudeMax": 121.92,
-        "boundaryPoints": [
-            {
-                "latitude": 38.31729702009844,
-                "longitude": -76.55617670782419
-            },
-            {
-                "latitude": 38.31594832826572,
-                "longitude": -76.55657341657302
-            },
-            {
-                "latitude": 38.31546739500083,
-                "longitude": -76.55376201277696
-            },
-            {
-                "latitude": 38.31470980862425,
-                "longitude": -76.54936361414539
-            },
-            {
-                "latitude": 38.31424154692598,
-                "longitude": -76.54662761646904
-            },
-            {
-                "latitude": 38.31369801280048,
-                "longitude": -76.54342380058223
-            },
-            {
-                "latitude": 38.31331079191371,
-                "longitude": -76.54109648475954
-            },
-            {
-                "latitude": 38.31529941346197,
-                "longitude": -76.54052104837133
-            },
-            {
-                "latitude": 38.31587643291039,
-                "longitude": -76.54361305817427
-            },
-            {
-                "latitude": 38.31861642463319,
-                "longitude": -76.54538594175376
-            },
-            {
-                "latitude": 38.31862683616554,
-                "longitude": -76.55206138505936
-            },
-            {
-                "latitude": 38.31703471119464,
-                "longitude": -76.55244787859773
-            },
-            {
-                "latitude": 38.31674255749409,
-                "longitude": -76.55294546866578
-            },
-            {
-                "latitude": 38.31729702009844,
-                "longitude": -76.55617670782419
-            }
-        ],
-        "odlcBoundaryZ1": [
-            {
-                "latitude": 38.315386,
-                "longitude": -76.550875
-            },
-            {
-                "latitude": 38.315683,
-                "longitude": -76.552586
-            },
-            {
-                "latitude": 38.315895,
-                "longitude": -76.552519
-            },
-            {
-                "latitude": 38.315607,
-                "longitude": -76.5508
-            }
-        ],
-        "odlcBoundaryZ2": [
-            {
-                "latitude": 38.314529,
-                "longitude": -76.545859
-            },
-            {
-                "latitude": 38.314731,
-                "longitude": -76.545792
-            },
-            {
-                "latitude": 38.314441,
-                "longitude": -76.544081
-            },
-            {
-                "latitude": 38.314228,
-                "longitude": -76.544156
-            }
-        ],
-        "mappingBoundaryZ1": [
-            {
-                "latitude": 38.314816,
-                "longitude": -76.548947
-            },
-            {
-                "latitude": 38.31546,
-                "longitude": -76.552653
-            },
-            {
-                "latitude": 38.316639,
-                "longitude": -76.55233
-            },
-            {
-                "latitude": 38.316016,
-                "longitude": -76.5486
-            }
-        ],
-        "mappingBoundaryZ2": [
-            {
-                "latitude": 38.314669,
-                "longitude": -76.547987
-            },
-            {
-                "latitude": 38.315873,
-                "longitude": -76.547611
-            },
-            {
-                "latitude": 38.315208,
-                "longitude": -76.54384
-            },
-            {
-                "latitude": 38.314008,
-                "longitude": -76.544237
-            }
-        ]
+  "flyzones": {
+    "altitudeMin": 23.4696,
+    "altitudeMax": 121.92,
+    "boundaryPoints": [
+      {
+        "latitude": 38.31729702009844,
+        "longitude": -76.55617670782419
+      },
+      {
+        "latitude": 38.31594832826572,
+        "longitude": -76.55657341657302
+      },
+      {
+        "latitude": 38.31546739500083,
+        "longitude": -76.55376201277696
+      },
+      {
+        "latitude": 38.31470980862425,
+        "longitude": -76.54936361414539
+      },
+      {
+        "latitude": 38.31424154692598,
+        "longitude": -76.54662761646904
+      },
+      {
+        "latitude": 38.31369801280048,
+        "longitude": -76.54342380058223
+      },
+      {
+        "latitude": 38.31331079191371,
+        "longitude": -76.54109648475954
+      },
+      {
+        "latitude": 38.31529941346197,
+        "longitude": -76.54052104837133
+      },
+      {
+        "latitude": 38.31587643291039,
+        "longitude": -76.54361305817427
+      },
+      {
+        "latitude": 38.31861642463319,
+        "longitude": -76.54538594175376
+      },
+      {
+        "latitude": 38.31862683616554,
+        "longitude": -76.55206138505936
+      },
+      {
+        "latitude": 38.31703471119464,
+        "longitude": -76.55244787859773
+      },
+      {
+        "latitude": 38.31674255749409,
+        "longitude": -76.55294546866578
+      },
+      {
+        "latitude": 38.31729702009844,
+        "longitude": -76.55617670782419
+      }
+    ],
+    "odlcBoundaryZ1": [
+      {
+        "latitude": 38.315386,
+        "longitude": -76.550875
+      },
+      {
+        "latitude": 38.315683,
+        "longitude": -76.552586
+      },
+      {
+        "latitude": 38.315895,
+        "longitude": -76.552519
+      },
+      {
+        "latitude": 38.315607,
+        "longitude": -76.5508
+      }
+    ],
+    "odlcBoundaryZ2": [
+      {
+        "latitude": 38.314529,
+        "longitude": -76.545859
+      },
+      {
+        "latitude": 38.314731,
+        "longitude": -76.545792
+      },
+      {
+        "latitude": 38.314441,
+        "longitude": -76.544081
+      },
+      {
+        "latitude": 38.314228,
+        "longitude": -76.544156
+      }
+    ],
+    "mappingBoundaryZ1": [
+      {
+        "latitude": 38.314816,
+        "longitude": -76.548947
+      },
+      {
+        "latitude": 38.31546,
+        "longitude": -76.552653
+      },
+      {
+        "latitude": 38.316639,
+        "longitude": -76.55233
+      },
+      {
+        "latitude": 38.316016,
+        "longitude": -76.5486
+      }
+    ],
+    "mappingBoundaryZ2": [
+      {
+        "latitude": 38.314669,
+        "longitude": -76.547987
+      },
+      {
+        "latitude": 38.315873,
+        "longitude": -76.547611
+      },
+      {
+        "latitude": 38.315208,
+        "longitude": -76.54384
+      },
+      {
+        "latitude": 38.314008,
+        "longitude": -76.544237
+      }
+    ]
+  },
+  "waypoints": [
+    {
+      "latitude": 0,
+      "longitude": 0,
+      "altitude": 30.5
     },
-    "waypoints": [
-        {
-            "latitude": 0,
-            "longitude": 0,
-            "altitude": 30.5
-        },
-        {
-            "latitude": 0,
-            "longitude": 0,
-            "altitude": 30.5
-        },
-        {
-            "latitude": 0,
-            "longitude": 0,
-            "altitude": 30.5
-        },
-        {
-            "latitude": 0,
-            "longitude": 0,
-            "altitude": 30.5
-        },
-        {
-            "latitude": 0,
-            "longitude": 0,
-            "altitude": 30.5
-        },
-        {
-            "latitude": 0,
-            "longitude": 0,
-            "altitude": 30.5
-        },
-        {
-            "latitude": 0,
-            "longitude": 0,
-            "altitude": 30.5
-        },
-        {
-            "latitude": 0,
-            "longitude": 0,
-            "altitude": 30.5
-        },
-        {
-            "latitude": 0,
-            "longitude": 0,
-            "altitude": 30.5
-        },
-        {
-            "latitude": 0,
-            "longitude": 0,
-            "altitude": 30.5
-        }
-    ],
-    "odlcAltitude": 24,
-    "odlcHeading": 13,
-    "odlcWaypointsZ1": [
-        {
-            "latitude": 38.315607,
-            "longitude": -76.5508
-        },
-        {
-            "latitude": 38.3154965,
-            "longitude": -76.5508375
-        },
-        {
-            "latitude": 38.315386,
-            "longitude": -76.550875
-        },
-        {
-            "latitude": 38.315895,
-            "longitude": -76.552519
-        },
-        {
-            "latitude": 38.315789,
-            "longitude": -76.5525525
-        },
-        {
-            "latitude": 38.315683,
-            "longitude": -76.552586
-        }
-    ],
-    "odlcWaypointsZ2": [
-        {
-            "latitude": 38.314731,
-            "longitude": -76.545792
-        },
-        {
-            "latitude": 38.31463,
-            "longitude": -76.5458255
-        },
-        {
-            "latitude": 38.314529,
-            "longitude": -76.545859
-        },
-        {
-            "latitude": 38.314441,
-            "longitude": -76.544081
-        },
-        {
-            "latitude": 38.3143345,
-            "longitude": -76.5441185
-        },
-        {
-            "latitude": 38.314228,
-            "longitude": -76.544156
-        }
-    ],
-    "airdropAltitude": 16.0
+    {
+      "latitude": 0,
+      "longitude": 0,
+      "altitude": 30.5
+    },
+    {
+      "latitude": 0,
+      "longitude": 0,
+      "altitude": 30.5
+    },
+    {
+      "latitude": 0,
+      "longitude": 0,
+      "altitude": 30.5
+    },
+    {
+      "latitude": 0,
+      "longitude": 0,
+      "altitude": 30.5
+    },
+    {
+      "latitude": 0,
+      "longitude": 0,
+      "altitude": 30.5
+    },
+    {
+      "latitude": 0,
+      "longitude": 0,
+      "altitude": 30.5
+    },
+    {
+      "latitude": 0,
+      "longitude": 0,
+      "altitude": 30.5
+    },
+    {
+      "latitude": 0,
+      "longitude": 0,
+      "altitude": 30.5
+    },
+    {
+      "latitude": 0,
+      "longitude": 0,
+      "altitude": 30.5
+    }
+  ],
+  "odlcAltitude": 24,
+  "odlcHeading": 13,
+  "odlcWaypointsZ1": [
+    {
+      "latitude": 38.315607,
+      "longitude": -76.5508
+    },
+    {
+      "latitude": 38.3154965,
+      "longitude": -76.5508375
+    },
+    {
+      "latitude": 38.315386,
+      "longitude": -76.550875
+    },
+    {
+      "latitude": 38.315895,
+      "longitude": -76.552519
+    },
+    {
+      "latitude": 38.315789,
+      "longitude": -76.5525525
+    },
+    {
+      "latitude": 38.315683,
+      "longitude": -76.552586
+    }
+  ],
+  "odlcWaypointsZ2": [
+    {
+      "latitude": 38.314731,
+      "longitude": -76.545792
+    },
+    {
+      "latitude": 38.31463,
+      "longitude": -76.5458255
+    },
+    {
+      "latitude": 38.314529,
+      "longitude": -76.545859
+    },
+    {
+      "latitude": 38.314441,
+      "longitude": -76.544081
+    },
+    {
+      "latitude": 38.3143345,
+      "longitude": -76.5441185
+    },
+    {
+      "latitude": 38.314228,
+      "longitude": -76.544156
+    }
+  ],
+  "defaultAirdropPointsZ1": [
+    {
+      "latitude": 38.31573,
+      "longitude": -76.55232
+    },
+    {
+      "latitude": 38.31566,
+      "longitude": -76.55191
+    },
+    {
+      "latitude": 38.31558,
+      "longitude": -76.55152
+    },
+    {
+      "latitude": 38.31551,
+      "longitude": -76.55112
+    }
+  ],
+  "defaultAirdropPointsZ2": [
+    {
+      "latitude": 38.31456,
+      "longitude": -76.54549
+    },
+    {
+      "latitude": 38.31451,
+      "longitude": -76.54515
+    },
+    {
+      "latitude": 38.31445,
+      "longitude": -76.5448
+    },
+    {
+      "latitude": 38.31438,
+      "longitude": -76.54444
+    }
+  ],
+  "airdropAltitude": 16.0
 }

--- a/flight/extract_gps.py
+++ b/flight/extract_gps.py
@@ -10,6 +10,8 @@ from typing_extensions import TypedDict
 
 import utm
 
+from vision.common.constants import Location
+
 
 # Initialize namedtuples to store latitude/longitude/altitude data for provided points
 class Waypoint(NamedTuple):
@@ -126,6 +128,7 @@ GPSData = TypedDict(
         "altitude_limits": list[float],
         "odlc_altitude": float,
         "odlc_heading": float,
+        "default_airdrop_points": list[Location],
         "airdrop_altitude": float,
     },
 )
@@ -277,6 +280,13 @@ def extract_gps(path: str) -> GPSData:
             The altitude to fly at during the ODLC state, in meters.
         odlc_heading : float
             Currently unused.
+        default_airdrop_points : list[Location]
+            The coordinates to perform airdrops at if no objects are detected.
+            Location : Location[float, float]
+                latitude : float
+                    The latitude of the waypoint, in degrees.
+                longitude : float
+                    The longitude of the waypoint, in degrees.
         airdrop_altitude : float
             The altitude to fly at during the Airdrop state, in meters
 
@@ -371,6 +381,7 @@ def extract_gps(path: str) -> GPSData:
         ],
         "odlc_altitude": json_data["odlcAltitude"],
         "odlc_heading": json_data["odlcHeading"],
+        "default_airdrop_points": json_data["defaultAirdropPoints"],
         "airdrop_altitude": json_data["airdropAltitude"],
     }
     return waypoint_data

--- a/state_machine/states/impl/airdrop_impl.py
+++ b/state_machine/states/impl/airdrop_impl.py
@@ -63,8 +63,8 @@ async def run(self: Airdrop) -> State:
                 fallback_locations: list[Location] = extract_gps(
                     self.flight_settings.mission_data_path
                 )["default_airdrop_points"]
-                for i in range(len(fallback_locations)):
-                    drop_locations[f"fallback_{i}"] = fallback_locations[i]
+                for i, location in enumerate(fallback_locations):
+                    drop_locations[f"fallback_{i}"] = location
 
         with open("flight/data/bottles.json", encoding="utf8") as output:
             cylinders: dict[str, dict[str, int | bool]] = json.load(output)

--- a/state_machine/states/impl/airdrop_impl.py
+++ b/state_machine/states/impl/airdrop_impl.py
@@ -53,6 +53,13 @@ async def run(self: Airdrop) -> State:
 
         with open("flight/data/output.json", encoding="utf8") as output:
             drop_locations: ODLCDict = json.load(output)
+            if not drop_locations:
+                logging.error("No drop locations found, loading fallback locations")
+                fallback_locations: list[Location] = extract_gps(
+                    self.flight_settings.mission_data_path
+                )["default_airdrop_points"]
+                for i in range(len(fallback_locations)):
+                    drop_locations[f"fallback_{i}"] = fallback_locations[i]
 
         with open("flight/data/bottles.json", encoding="utf8") as output:
             cylinders: dict[str, dict[str, int | bool]] = json.load(output)

--- a/state_machine/states/impl/airdrop_impl.py
+++ b/state_machine/states/impl/airdrop_impl.py
@@ -26,6 +26,11 @@ from state_machine.states.waypoint import Waypoint
 
 from vision.common.constants import Location, ODLCDict
 
+# The altitude to go up to while staying at the airdrop point
+# This could allow stuck beacons to wiggle out
+# 75 ft -> 23 m
+WIGGLE_ALTITUDE: float = 23.0
+
 
 async def run(self: Airdrop) -> State:
     """
@@ -225,7 +230,13 @@ async def attempt_drop(
         with open("flight/data/attempted_drops.json", "w", encoding="utf8") as file:
             json.dump(list(attempted_locations), file)
 
-        await asyncio.sleep(15)
+        await asyncio.sleep(12)
+
+        # Attempt to wiggle out stuck beacons
+        logging.info("Moving up to 75 ft / 23 meters...")
+        await move_to(drone.vehicle, drop_lat, drop_lon, WIGGLE_ALTITUDE)
+        await asyncio.sleep(3)
+
         logging.info("-- Airdrop done!")
         return True
 

--- a/state_machine/states/impl/odlc_impl.py
+++ b/state_machine/states/impl/odlc_impl.py
@@ -108,6 +108,8 @@ async def find_odlcs(self: ODLC, capture_status: asyncio.Event) -> None:
     # Initialize the camera
     if self.flight_settings.sim_mode is SimMode.REAL:
         camera: CameraIRL | CameraAirSim | None = CameraIRL()
+        # The gimbal takes some time to adjust its angle, wait for it to be ready
+        await asyncio.sleep(3)
     elif self.flight_settings.sim_mode is SimMode.AIRSIM:
         camera = CameraAirSim()
     else:

--- a/state_machine/states/impl/waypoint_impl.py
+++ b/state_machine/states/impl/waypoint_impl.py
@@ -33,6 +33,7 @@ from state_machine.state_tracker import (
 )
 
 BOUNDARY_SHRINKAGE: Final[float] = 5.0  # in meters
+WAYPOINT_AIR_SPEED: Final[float] = 25.0  # in meters/second
 
 
 async def run(self: Waypoint) -> State:
@@ -163,9 +164,13 @@ async def waypoint_logic(self: Waypoint) -> None:
                 (waypoint.altitude - curr_altitude) / path_length
             ) * line_segment.length()
 
-            await move_to(self.drone.vehicle, lat_deg, lon_deg, curr_altitude)
+            await move_to(
+                self.drone.vehicle, lat_deg, lon_deg, curr_altitude, airspeed=WAYPOINT_AIR_SPEED
+            )
 
-        await move_to(self.drone.vehicle, lat_deg, lon_deg, waypoint.altitude)
+        await move_to(
+            self.drone.vehicle, lat_deg, lon_deg, waypoint.altitude, airspeed=WAYPOINT_AIR_SPEED
+        )
 
         logging.info("Reached waypoint %d", waypoint_num)
 

--- a/vision/pipeline/pipeline_utils.py
+++ b/vision/pipeline/pipeline_utils.py
@@ -9,6 +9,26 @@ from vision.common.bounding_box import BoundingBox
 from vision.deskew.camera_distances import get_coordinates
 from vision.yolo.model import ObjectDetection
 
+# We only care about the object classes that will actually appear in the competition
+# You can see which are which here: https://github.com/WongKinYiu/yolov9/blob/main/data/coco.yaml
+CLASS_PRIORITIES: dict[str, float] = {
+    "person": 0.5,
+    "car": 1.0,
+    "motorcycle": 1.0,
+    "airplane": 1.0,
+    "bus": 1.0,
+    "boat": 1.0,
+    "stop sign": 1.0,
+    "umbrella": 1.0,
+    "suitcase": 1.0,
+    "skis": 1.0,
+    "snowboard": 1.0,
+    "sports ball": 1.0,
+    "baseball bat": 1.0,
+    "tennis racket": 1.0,
+    "bed": 1.0,
+}
+
 
 def read_parameter_json(json_path: str) -> dict[str, consts.CameraParameters]:
     """
@@ -139,3 +159,28 @@ def detection_to_bbox(
     set_generic_attributes(bbox, detection.image, detection.shape, parameters)
 
     return bbox
+
+
+def adjust_confidences(
+    detections: list[ObjectDetection], expand_categories: bool = False, buffer: float = 0.0
+) -> None:
+    """
+    Adjusts the confidence of ObjectDetections based on whether
+    they are in the competition list or not.
+    new_confidence = detection.confidence + buffer * CLASS_PRIORITIES[detection.category]
+
+    Parameters
+    ----------
+    detections: list[ObjectDetection]
+        The list of object detections to adjust
+    expand_categories : bool, default False
+        Whether to include categories not in the competition set
+    buffer : float, default 0.0
+        The value to add to confidence values of categories in the competition set
+    """
+    detection: ObjectDetection
+    for detection in detections:
+        if detection.category in CLASS_PRIORITIES:
+            detection.confidence += buffer * CLASS_PRIORITIES[detection.category]
+        elif not expand_categories:
+            continue

--- a/vision/pipeline/standard_pipeline.py
+++ b/vision/pipeline/standard_pipeline.py
@@ -168,7 +168,7 @@ def create_odlc_dict(
 def proximity_check(
     detections: list[ObjectDetection],
     parameters: dict[str, consts.CameraParameters],
-    min_distance: float = 15.0,
+    min_distance: float = 7.0,
 ) -> list[tuple[ObjectDetection, BoundingBox]]:
     """
     Checks for detections that are too close to each other, and
@@ -183,7 +183,7 @@ def proximity_check(
         A dictionary with the image parameters for every
         captured image.
     min_distance : float, optional
-        The minimum distance between objects in METERS, by default 15.0
+        The minimum distance between objects in METERS, by default 7.0
 
     Returns
     -------
@@ -193,7 +193,7 @@ def proximity_check(
     """
     filtered_detections: list[tuple[ObjectDetection, BoundingBox]] = []
     # If we sort the detections by confidence, we can stop as soon as we find a collision
-    detections.sort(key=lambda entry: -entry.confidence)
+    detections.sort(key=lambda entry: entry.confidence, reverse=True)
 
     for detection in detections:
         image_name: str = detection.image.split("/")[-1]

--- a/vision/pipeline/standard_pipeline.py
+++ b/vision/pipeline/standard_pipeline.py
@@ -1,11 +1,11 @@
 """Functions that perform standard object detection, localization, and classification"""
 
-import heapq
 from typing import Iterable, TypeAlias
 
 import utm
 
 from flight.extract_gps import extract_gps, GPSData
+from flight.waypoint.calculate_distance import calculate_distance
 from flight.waypoint.geometry import Point
 
 from state_machine.flight_settings import FlightSettings
@@ -25,26 +25,6 @@ import vision.pipeline.pipeline_utils as pipe_utils
 from vision.yolo.model import ObjectDetection
 
 ContourHierarchyList: TypeAlias = list[tuple[tuple[consts.Contour, ...], consts.Hierarchy]]
-
-# We only care about the object classes that will actually appear in the competition
-# You can see which are which here: https://github.com/WongKinYiu/yolov9/blob/main/data/coco.yaml
-CLASS_PRIORITIES: dict[str, float] = {
-    "person": 0.5,
-    "car": 1.0,
-    "motorcycle": 1.0,
-    "airplane": 1.0,
-    "bus": 1.0,
-    "boat": 1.0,
-    "stop sign": 1.0,
-    "umbrella": 1.0,
-    "suitcase": 1.0,
-    "skis": 1.0,
-    "snowboard": 1.0,
-    "sports ball": 1.0,
-    "baseball bat": 1.0,
-    "tennis racket": 1.0,
-    "bed": 1.0,
-}
 
 
 def find_standard_objects(
@@ -185,53 +165,58 @@ def create_odlc_dict(
     return odlc_dict
 
 
-def filter_objects(
-    detections: dict[str, ObjectDetection],
-    expand_categories: bool = False,
-    buffer: float = 0.0,
-    output_count: int = 4,
-) -> dict[str, ObjectDetection]:
+def proximity_check(
+    detections: list[ObjectDetection],
+    parameters: dict[str, consts.CameraParameters],
+    min_distance: float = 15.0,
+) -> list[tuple[ObjectDetection, BoundingBox]]:
     """
-    Filters out objects to the best 4 detections.
-    Only needs to be called if there are more than 4 detections.
-    You can enable expand_categories to allow categories that are not in the competition
-    set, and use buffer to set a higher priority for categories that are.
-    The buffer will be added to the confidence value of the categories in the set.
+    Checks for detections that are too close to each other, and
+    removes the one with lower confidence.
+    The ruleset states that objects must be at least 50 feet apart.
 
     Parameters
     ----------
-    detections : dict[str, ObjectDetection]
-        The dictionary of detections to filter
-    expand_categories : bool, default False
-        Whether to include categories not in the competition set
-    buffer : float, default 0.0
-        The value to add to confidence values of categories in the competition set
-    output_count : int, default 4
-        The maximum number of detections to output
+    detections : list[ObjectDetection]
+        A list with all object detections.
+    parameters : dict[str, consts.CameraParameters]
+        A dictionary with the image parameters for every
+        captured image.
+    min_distance : float, optional
+        The minimum distance between objects in METERS, by default 15.0
 
     Returns
     -------
-    filtered_detections: dict[str, ObjectDetection]
-        The dictionary of filtered detections
+    filtered_detections : list[tuple[ObjectDetection, BoundingBox]]
+        All detections that are at least `min_distance` apart, along with
+        their bounding boxes.
     """
-    best_detections: list[tuple[float, str, ObjectDetection]] = []  # min heap
+    filtered_detections: list[tuple[ObjectDetection, BoundingBox]] = []
+    # If we sort the detections by confidence, we can stop as soon as we find a collision
+    detections.sort(key=lambda entry: -entry.confidence)
 
-    # Get the entries with the highest confidence
-    category: str
-    detection: ObjectDetection
-    for category, detection in detections.items():
-        confidence: float = detection.confidence
-        if category in CLASS_PRIORITIES:
-            confidence += buffer * CLASS_PRIORITIES[category]
-        elif not expand_categories:
-            continue
+    for detection in detections:
+        image_name: str = detection.image.split("/")[-1]
+        image_parameters: consts.CameraParameters = parameters[image_name]
+        bounding_box: BoundingBox = pipe_utils.detection_to_bbox(detection, image_parameters)
+        latitude: float = bounding_box.get_attribute("latitude")
+        longitude: float = bounding_box.get_attribute("longitude")
 
-        heap_entry: tuple[float, str, ObjectDetection] = confidence, category, detection
-        if len(best_detections) == output_count:
-            heapq.heappushpop(best_detections, heap_entry)
-        else:
-            heapq.heappush(best_detections, heap_entry)
+        collided: bool = False
+        existing_bbox: BoundingBox
+        for _, existing_bbox in filtered_detections:
+            existing_latitude: float = existing_bbox.get_attribute("latitude")
+            existing_longitude: float = existing_bbox.get_attribute("longitude")
 
-    # Sort by confidence from highest to lowest (dicts maintain insertion order)
-    best_detections.sort(key=lambda entry: -entry[0])
-    return {entry[1]: entry[2] for entry in best_detections}
+            # We can use 0 altitude for calculation as the search area is pretty flat
+            distance: float = calculate_distance(
+                latitude, longitude, 0, existing_latitude, existing_longitude, 0
+            )
+            if distance < min_distance:
+                collided = True
+                break
+
+        if not collided:
+            filtered_detections.append((detection, bounding_box))
+
+    return filtered_detections

--- a/vision/unit_tests/yolo_queue_test.py
+++ b/vision/unit_tests/yolo_queue_test.py
@@ -7,14 +7,13 @@ import os
 import sys
 from typing import Iterable
 
-from vision.pipeline.standard_pipeline import filter_objects
+from vision.common.bounding_box import BoundingBox
+from vision.pipeline import pipeline_utils, standard_pipeline
 from vision.yolo.model import ObjectDetection
 from vision.yolo.queue import PhotoQueue
 
 
-async def run_queue(
-    images: Iterable[str], test_early_stop: bool = False
-) -> dict[str, ObjectDetection]:
+async def run_queue(images: Iterable[str], test_early_stop: bool = False) -> list[ObjectDetection]:
     """
     Test the PhotoQueue class by adding images to the queue and running inference on them.
 
@@ -27,8 +26,8 @@ async def run_queue(
 
     Returns
     -------
-    dict[str, ObjectDetection]
-        A dictionary mapping image paths to their corresponding best ObjectDetection results.
+    list[ObjectDetection]
+        A list of ObjectDetection results.
     """
     initial_size: int = 0
     queue: PhotoQueue = PhotoQueue(True)
@@ -64,13 +63,28 @@ def get_all_images(path: str, limit: int = 10) -> list[str]:
     return list(itertools.islice((os.path.join(path, f.name) for f in os.scandir(path)), limit))
 
 
-async def test_queue() -> None:
-    """Runs the YOLO queue test. Prints each filtered detection."""
+async def test_queue(camera_data_path: str | None = None) -> None:
+    """Runs the YOLO queue test. Prints each filtered detection.
+
+    Parameters
+    ----------
+    camera_data_path : str | None, default=None
+        A file storing photo metadata, used for proximity detection.
+        If none the proximity check is skipped.
+    """
     directory: str = sys.argv[1]
-    all_images: list[str] = get_all_images(directory)
-    results: dict[str, ObjectDetection] = await run_queue(all_images)
-    filtered: dict[str, ObjectDetection] = filter_objects(results, True, 0.2)
-    for result in filtered.values():
+    all_images: list[str] = get_all_images(directory, 10)
+    results: list[ObjectDetection] = await run_queue(all_images)
+    pipeline_utils.adjust_confidences(results, True, 0.5)
+    if camera_data_path is not None:
+        image_parameters = pipeline_utils.read_parameter_json(camera_data_path)
+        filtered_objects: list[tuple[ObjectDetection, BoundingBox]] = (
+            standard_pipeline.proximity_check(results, image_parameters, 7)
+        )
+        results = [detection for detection, _ in filtered_objects]
+    if len(results) > 4:
+        results = results[:4]
+    for result in results:
         logging.info(
             "Detected %s at (%d, %d), (%d, %d) Cfd: %.2f Img: %s",
             result.category,
@@ -88,4 +102,4 @@ if __name__ == "__main__":
     if len(sys.argv) < 2:
         logging.info("Need to provide a directory")
         sys.exit(1)
-    asyncio.run(test_queue())
+    asyncio.run(test_queue("flight/data/camera.json"))

--- a/vision/vision_pipeline.py
+++ b/vision/vision_pipeline.py
@@ -71,22 +71,25 @@ async def flyover_pipeline(
                 await queue.add_photo(full_image_path)
 
     # End the queue, get results
-    detected_objects: dict[str, ObjectDetection] = await queue.end_queue()
+    detected_objects: list[ObjectDetection] = await queue.end_queue()
 
     # Load in the json containing the camera data
     image_parameters = pipe_utils.read_parameter_json(camera_data_path)
 
-    detected_objects = std_obj.filter_objects(
-        detected_objects, True, 0.5, flight_settings.standard_object_count
-    )
+    # Adjust confidences based on class
+    pipe_utils.adjust_confidences(detected_objects, True, 0.5)
 
-    # Convert the final detections to BoundingBoxes
-    bounding_boxes: list[BoundingBox] = []
-    detection: ObjectDetection
-    for detection in detected_objects.values():
-        image_name: str = detection.image.split("/")[-1]
-        parameters: consts.CameraParameters = image_parameters[image_name]
-        bounding_boxes.append(pipe_utils.detection_to_bbox(detection, parameters))
+    # Check for boundary collisions between predictions
+    filtered_objects: list[tuple[ObjectDetection, BoundingBox]] = std_obj.proximity_check(
+        detected_objects, image_parameters, 7
+    )
+    # From this point on we can assume that the predictions are sorted by confidence
+
+    bounding_boxes: list[BoundingBox] = [box for _, box in filtered_objects]
+
+    # Take the highest confidence predictions
+    if len(bounding_boxes) > flight_settings.standard_object_count:
+        bounding_boxes = bounding_boxes[: flight_settings.standard_object_count]
 
     odlc_dict: consts.ODLCDict = std_obj.create_odlc_dict(bounding_boxes, flight_settings)
     logging.info("%d ODLCs found: %s", len(odlc_dict), odlc_dict)

--- a/vision/vision_pipeline.py
+++ b/vision/vision_pipeline.py
@@ -88,8 +88,7 @@ async def flyover_pipeline(
     bounding_boxes: list[BoundingBox] = [box for _, box in filtered_objects]
 
     # Take the highest confidence predictions
-    if len(bounding_boxes) > flight_settings.standard_object_count:
-        bounding_boxes = bounding_boxes[: flight_settings.standard_object_count]
+    bounding_boxes = bounding_boxes[: flight_settings.standard_object_count]
 
     odlc_dict: consts.ODLCDict = std_obj.create_odlc_dict(bounding_boxes, flight_settings)
     logging.info("%d ODLCs found: %s", len(odlc_dict), odlc_dict)

--- a/vision/yolo/model.py
+++ b/vision/yolo/model.py
@@ -244,6 +244,18 @@ class ObjectDetection:
         """
         return self._confidence
 
+    @confidence.setter
+    def confidence(self, value: float) -> None:
+        """
+        Sets the confidence of the object detection.
+
+        Parameters
+        ----------
+        value : float
+            The new confidence value.
+        """
+        self._confidence = value
+
     @property
     def image(self) -> str:
         """

--- a/vision/yolo/queue.py
+++ b/vision/yolo/queue.py
@@ -142,6 +142,15 @@ class PhotoQueue:
                 (0, 255, 0),
                 2,
             )
+            # Add caption with class
+            cv2.putText(
+                image,
+                detection.category,
+                (conv[0], conv[1] - 5),
+                cv2.FONT_HERSHEY_TRIPLEX,
+                (conv[2] - conv[0]) / 250,
+                (0, 255, 0),
+            )
         return image
 
     def _print_results(self) -> None:

--- a/vision/yolo/queue.py
+++ b/vision/yolo/queue.py
@@ -189,7 +189,6 @@ class PhotoQueue:
                 else:
                     self.results[result.category] = result
             if self.show_results:
-                cv2.imshow(f"Runner {num} Results", await self._draw_results(image, results))
                 cv2.waitKey(1)
             self.queue.task_done()
             logging.debug("Runner %d finished processing image %s", num, image)
@@ -210,13 +209,13 @@ class PhotoQueue:
             runner = asyncio.create_task(self.photo_runner(i + 1))
             self.runners.append(runner)
 
-    async def end_queue(self) -> dict[str, ObjectDetection]:
+    async def end_queue(self) -> list[ObjectDetection]:
         """
         Ends the tasks of runners and returns the results.
 
         Returns
         -------
-        dict[str, ObjectDetection]
+        list[ObjectDetection]
             The results of the object detection
         """
         # Cancel the queue to stop runners once the queue is empty
@@ -226,4 +225,4 @@ class PhotoQueue:
 
         cv2.destroyAllWindows()
 
-        return self.results
+        return list(self.results.values())

--- a/vision/yolo/queue.py
+++ b/vision/yolo/queue.py
@@ -182,7 +182,7 @@ class PhotoQueue:
         """
         window_title: str = f"Runner {num} Results"
         if self.show_results:
-            cv2.namedWindow(window_title, cv2.WINDOW_NORMAL)
+            cv2.namedWindow(window_title, cv2.WINDOW_KEEPRATIO)
             cv2.resizeWindow(window_title, 1280, 720)
 
         while True:
@@ -213,7 +213,6 @@ class PhotoQueue:
             self._print_results()
             self.queue.task_done()
             logging.debug("Runner %d finished processing image %s", num, image)
-            await asyncio.sleep(5)
 
         if self.show_results:
             cv2.destroyWindow(f"Runner {num} Results")

--- a/vision/yolo/queue.py
+++ b/vision/yolo/queue.py
@@ -180,8 +180,10 @@ class PhotoQueue:
         num : int
             The id of the runner.
         """
+        window_title: str = f"Runner {num} Results"
         if self.show_results:
-            cv2.namedWindow(f"Runner {num} Results")
+            cv2.namedWindow(window_title, cv2.WINDOW_NORMAL)
+            cv2.resizeWindow(window_title, 1280, 720)
 
         while True:
             # We want to cancel the task if we are done capturing images,
@@ -205,10 +207,13 @@ class PhotoQueue:
                 else:
                     self.results[result.category] = result
             if self.show_results:
+                annotated_image = await self._draw_results(image, results)
+                cv2.imshow(window_title, annotated_image)
                 cv2.waitKey(1)
             self._print_results()
             self.queue.task_done()
             logging.debug("Runner %d finished processing image %s", num, image)
+            await asyncio.sleep(5)
 
         if self.show_results:
             cv2.destroyWindow(f"Runner {num} Results")

--- a/vision/yolo/queue.py
+++ b/vision/yolo/queue.py
@@ -10,14 +10,14 @@ import numpy as np
 
 from vision.yolo.model import YOLO, ObjectDetection
 
-T = TypeVar("T")
+QueueItem = TypeVar("QueueItem")
 
 
 class QueueCancelled(Exception):
     """Exception raised when the queue is cancelled."""
 
 
-class CancellableQueue(asyncio.Queue[T]):
+class CancellableQueue(asyncio.Queue[QueueItem]):
     """
     A subclass of the asyncio Queue that adds an event to cancel the queue.
 
@@ -37,17 +37,17 @@ class CancellableQueue(asyncio.Queue[T]):
     def __init__(self, maxsize: int = 0) -> None:
         super().__init__(maxsize)
         self._cancelled: bool = False
-        self._queue: collections.deque[T]
+        self._queue: collections.deque[QueueItem]
         self._getters: collections.deque[asyncio.Future[None]]
 
-    def _get(self) -> T:
+    def _get(self) -> QueueItem:
         """
         Get an item from the queue.
         Overrides the _get method of the asyncio.Queue class.
 
         Returns
         -------
-        T
+        QueueItem
             The next item from the queue
 
         Raises
@@ -144,6 +144,22 @@ class PhotoQueue:
             )
         return image
 
+    def _print_results(self) -> None:
+        """
+        Prints out all of the stored results, including bbox, confidence, and image path.
+        """
+        for result in self.results.values():
+            logging.info(
+                "Detected %s at (%d, %d), (%d, %d) Cfd: %.2f Img: %s",
+                result.category,
+                result.bbox[0],
+                result.bbox[1],
+                result.bbox[2],
+                result.bbox[3],
+                result.confidence,
+                result.image,
+            )
+
     async def add_photo(self, photo_path: str) -> None:
         """
         Add a photo to the queue for processing.
@@ -190,6 +206,7 @@ class PhotoQueue:
                     self.results[result.category] = result
             if self.show_results:
                 cv2.waitKey(1)
+            self._print_results()
             self.queue.task_done()
             logging.debug("Runner %d finished processing image %s", num, image)
 


### PR DESCRIPTION
Adds a check to the detection filtering process to remove predictions that are too close to each other.
Adds default airdrop locations to drop objects at when no suitable predictions are made.
Adds multiple logging improvements in the ODLC state and YOLO queue system.
Fix airspeed being set low after the ODLC or Mapping states.