### PR TITLE
Allow for YOLO inference during Mapping, put Mapping state after ODLC

### DIFF
--- a/state_machine/flight_settings.py
+++ b/state_machine/flight_settings.py
@@ -1,5 +1,6 @@
 """Class to contain setters, getters & parameters for current flight"""
 
+from asyncio import Event
 from enum import Enum
 import logging
 import sys
@@ -23,6 +24,7 @@ class SimMode(Enum):
     AIRSIM = "airsim"
 
 
+# pylint: disable=too-many-instance-attributes
 class FlightSettings:
     """
     Class to contain basic information for a flight, as well as some flight parameters
@@ -52,6 +54,9 @@ class FlightSettings:
         Whether the drone is real, running in the ardupilot sim, or running in airsim
     __mission_data_path: str
         The path to the JSON file containing the boundary and waypoint data.
+    __yolo_status: Event
+        An asyncio Event tracking whether the YOLO model has
+        finished processing images.
 
     Methods
     -------
@@ -146,6 +151,7 @@ class FlightSettings:
         self.__standard_object_count: int = standard_object_count
         self.__sim_mode: SimMode = sim_mode
         self.__mission_data_path: str = mission_data_path
+        self.__yolo_status: Event = Event()
 
     @staticmethod
     def from_mission_config() -> "FlightSettings":
@@ -402,3 +408,15 @@ class FlightSettings:
         mission_data_path : str
             The path to the JSON file containing the boundary and waypoint data.
         """
+
+    @property
+    def yolo_status(self) -> Event:
+        """
+        Return the asyncio Event that tracks for completion of image processing.
+
+        Returns
+        -------
+        yolo_status : Event
+            The Event with status tracking the YOLO model.
+        """
+        return self.__yolo_status

--- a/state_machine/states/impl/airdrop_impl.py
+++ b/state_machine/states/impl/airdrop_impl.py
@@ -33,8 +33,9 @@ async def run(self: Airdrop) -> State:
 
     Returns
     -------
-    Waypoint : State
-        The next state after the drone has successfully completed the Airdrop.
+    Waypoint | Land : State
+        Goes to the Waypoint state if there is another airdrop to complete,
+        or Land if there are no more airdrops to complete.
 
     Notes
     -----

--- a/state_machine/states/impl/airdrop_impl.py
+++ b/state_machine/states/impl/airdrop_impl.py
@@ -20,7 +20,7 @@ from state_machine.drone import Drone
 from state_machine.flight_settings import FlightSettings, SimMode
 
 from state_machine.states.airdrop import Airdrop
-from state_machine.states.mapping import Mapping
+from state_machine.states.land import Land
 from state_machine.states.state import State
 from state_machine.states.waypoint import Waypoint
 
@@ -43,7 +43,7 @@ async def run(self: Airdrop) -> State:
     """
 
     if self.flight_settings.skip_odlc_and_airdrop:
-        return Mapping(self.drone, self.flight_settings)
+        return Land(self.drone, self.flight_settings)
 
     try:
         update_state("Airdrop")
@@ -78,7 +78,7 @@ async def run(self: Airdrop) -> State:
                 cylinder_num = cylinder
         else:
             logging.warning("No beacons are loaded?")
-            return Mapping(self.drone, self.flight_settings)
+            return Land(self.drone, self.flight_settings)
 
         dropped: bool = await attempt_drop(
             self.drone,
@@ -105,7 +105,7 @@ async def run(self: Airdrop) -> State:
 
         if continue_run:
             return Waypoint(self.drone, self.flight_settings)
-        return Mapping(self.drone, self.flight_settings)
+        return Land(self.drone, self.flight_settings)
 
     except asyncio.CancelledError as ex:
         logging.error("Airdrop state canceled")

--- a/state_machine/states/impl/land_impl.py
+++ b/state_machine/states/impl/land_impl.py
@@ -35,6 +35,7 @@ async def run(self: Land) -> None:
         logging.info("Land state running")
 
         # Instruct the drone to land
+        self.drone.vehicle.airspeed = 20
         await self.drone.return_to_launch()
 
         logging.info("Land state complete.")

--- a/state_machine/states/impl/mapping_impl.py
+++ b/state_machine/states/impl/mapping_impl.py
@@ -36,6 +36,8 @@ async def run(self: Mapping) -> State:
     Implements the run method for the Mapping state.
 
     This method captures photos of the mapping area and then transitions to the Airdrop state.
+    If YOLO inference from the ODLC state is still running, the code will wait for it to finish
+    before transitioning to the Airdrop state.
 
     Returns
     -------
@@ -147,7 +149,10 @@ async def run(self: Mapping) -> State:
         raise ex
 
     # Need to wait for YOLO processing to finish, or we may not have objects to drop at
-    if not self.flight_settings.yolo_status.is_set():
+    if (
+        not self.flight_settings.yolo_status.is_set()
+        and not self.flight_settings.skip_odlc_and_airdrop
+    ):
         logging.info("Waiting for YOLO processing to finish...")
         await self.flight_settings.yolo_status.wait()
         logging.info("YOLO processing finished.")

--- a/state_machine/states/impl/mapping_impl.py
+++ b/state_machine/states/impl/mapping_impl.py
@@ -20,7 +20,7 @@ from state_machine.state_tracker import (
     update_drone,
     update_flight_settings,
 )
-from state_machine.states.land import Land
+from state_machine.states.airdrop import Airdrop
 from state_machine.states.mapping import Mapping
 from state_machine.states.state import State
 from vision.common import camera_config
@@ -35,11 +35,11 @@ async def run(self: Mapping) -> State:
     """
     Implements the run method for the Mapping state.
 
-    This method captures photos of the mapping area and then transitions to the ODLC state.
+    This method captures photos of the mapping area and then transitions to the Airdrop state.
 
     Returns
     -------
-    ODLC : State
+    Airdrop : State
         The next state after the drone has successfully landed.
     """
 
@@ -146,7 +146,13 @@ async def run(self: Mapping) -> State:
         logging.error("Mapping state canceled")
         raise ex
 
-    return Land(self.drone, self.flight_settings)
+    # Need to wait for YOLO processing to finish, or we may not have objects to drop at
+    if not self.flight_settings.yolo_status.is_set():
+        logging.info("Waiting for YOLO processing to finish...")
+        await self.flight_settings.yolo_status.wait()
+        logging.info("YOLO processing finished.")
+
+    return Airdrop(self.drone, self.flight_settings)
 
 
 # Setting the run_callable attribute of the Mapping class to the run function

--- a/state_machine/states/impl/odlc_impl.py
+++ b/state_machine/states/impl/odlc_impl.py
@@ -14,7 +14,6 @@ from state_machine.state_tracker import (
     update_drone,
     update_flight_settings,
 )
-from state_machine.states.airdrop import Airdrop
 from state_machine.states.mapping import Mapping
 from state_machine.states.odlc import ODLC
 from state_machine.states.state import State
@@ -28,7 +27,7 @@ async def run(self: ODLC) -> State:
     Implements the run method for the ODLC state.
 
     This method initiates the ODLC scanning process of the drone, takes pictures and transfers
-    picture data to the vision code, and then transitions to the Airdrop state.
+    picture data to the vision code, and then transitions to the Mapping state.
 
     Parameters
     ----------
@@ -37,7 +36,7 @@ async def run(self: ODLC) -> State:
 
     Returns
     -------
-    Airdrop : State
+    Mapping : State
         The next state after the drone has successfully scanned the ODLC area.
 
     Raises
@@ -57,31 +56,25 @@ async def run(self: ODLC) -> State:
         update_flight_settings(self.flight_settings)
         logging.info("ODLC state running")
 
-        capture_status = asyncio.Event()
+        capture_status: asyncio.Event = asyncio.Event()
 
-        vision_task: asyncio.Task[None] = asyncio.ensure_future(
-            vision_odlc_logic(self, capture_status)
-        )
+        asyncio.ensure_future(vision_odlc_logic(self, capture_status))
 
         flight_task: asyncio.Task[None] = asyncio.ensure_future(find_odlcs(self, capture_status))
 
-        logging.info("Starting check for task completion")
-
-        while not vision_task.done():
-            await asyncio.sleep(0.25)
+        logging.info("Starting check for flight task completion")
 
         while not flight_task.done():
             await asyncio.sleep(0.25)
 
-        logging.info("ODLC scan complete. State completing...")
-        vision_task.cancel()
+        logging.info("ODLC flight scan complete. State completing...")
         flight_task.cancel()
     except asyncio.CancelledError as ex:
         logging.error("ODLC state canceled")
         traceback.print_exc()
         raise ex
 
-    return Airdrop(self.drone, self.flight_settings)
+    return Mapping(self.drone, self.flight_settings)
 
 
 async def find_odlcs(self: ODLC, capture_status: asyncio.Event) -> None:
@@ -156,6 +149,7 @@ async def find_odlcs(self: ODLC, capture_status: asyncio.Event) -> None:
                 point.latitude,
                 point.longitude,
                 gps_data["odlc_altitude"],
+                airspeed=5,
             )
 
     if camera:

--- a/vision/vision_pipeline.py
+++ b/vision/vision_pipeline.py
@@ -91,3 +91,4 @@ async def flyover_pipeline(
     odlc_dict: consts.ODLCDict = std_obj.create_odlc_dict(bounding_boxes, flight_settings)
     logging.info("%d ODLCs found: %s", len(odlc_dict), odlc_dict)
     pipe_utils.output_odlc_json(output_path, odlc_dict)
+    flight_settings.yolo_status.set()


### PR DESCRIPTION
With the new YOLO tiling addition, image inference takes quite a while, causing the drone to stay in the air for minutes waiting for inference to be finished. This branch removes the check for the ODLC vision task to be finished and moves it to the Mapping state, allowing for mapping images to be taken while YOLO inference is still being done, saving competition time.